### PR TITLE
Implement support for RP2350 Interpolator differences

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 project(rp2040-interp CXX)
 
 option(RP2040_INTERP_WITH_HARDWARE "use RP2040 hardware interpolator" OFF)
+option(RP2040_INTERP_GENERATION_RP2350 "default to RP2350 interpolator generation" OFF)
 option(RP2040_INTERP_WITH_TESTS "use common test library" OFF)
 
 add_library(rp2040-interp INTERFACE)
@@ -12,6 +13,9 @@ target_include_directories(${PROJECT_NAME} INTERFACE include/)
 if(${RP2040_INTERP_WITH_HARDWARE})
     target_compile_definitions(${PROJECT_NAME} INTERFACE RP2040_INTERP_WITH_HARDWARE=1)
     target_link_libraries(${PROJECT_NAME} INTERFACE hardware_interp)
+endif()
+if(${RP2040_INTERP_GENERATION_RP2350})
+    target_compile_definitions(${PROJECT_NAME} INTERFACE RP2040_INTERP_GENERATION_RP2350=1)
 endif()
 
 if(${RP2040_INTERP_WITH_TESTS})

--- a/README.md
+++ b/README.md
@@ -152,7 +152,40 @@ header `include/interp.h`.
 
 The `python/` folder contains the python package `rp2040_interp`.
 
-TODO: more documentation
+- `class InterpGeneration(Enum)`: identifies the Interpolator variant
+  - `RP2040`
+  - `RP2350`
+
+- `class InterpCtrl`: Interpolator lane settings dataclass
+  - `shift: int`
+  - `mask_lsb: int`
+  - `mask_msb: int`
+  - `is_signed: bool`
+  - `cross_input: bool`
+  - `cross_result: bool`
+  - `add_raw: bool`
+  - `force_msb: int`
+  - `blend: bool`
+  - `clamp: bool`
+  - `overf0: bool`
+  - `overf1: bool`
+  - `overf: bool`
+  - `def from_reg(value: int) -> InterpCtrl`: convert from packed form
+  - `def to_reg(self) -> int`: convert to packed form
+
+- `class Interp`: Software Simulation of an Interpolator
+  - `def __init__(self, n: int = 0, generation: InterpGeneration = InterpGeneration.RP2040)`: constructor
+    - n must be 0 or 1 and describes which interpolator instance is used
+    - generation must be a variant of InterpGeneration and describes which generation of Interpolator is simulated
+  - `accum: List[int] # len = 2`
+  - `base: List[int]  # len = 3`
+  - `ctrl: List[int]  # len = 2`
+  - `def pop(i: int) -> int`: simulate read from `POP_LANE0` (i=0), `POP_LANE1` (i=1), or `POP_FULL` (i=2) registers
+  - `def peek(i: int) -> int`: simulate read from `PEEK_LANE0` (i=0), `PEEK_LANE1` (i=1), or `PEEK_FULL` (i=2) registers
+  - `def peekraw(i: int) -> int`: simulate read from `ACCUM0_ADD` (i=0) or `ACCUM1_ADD` (i=1) registers
+  - `def add(i: int, v: int)`: simulate write to `ACCUM0_ADD` (i=0) or `ACCUM1_ADD` (i=1) registers
+  - `def base01(v: int)`: simulate write to `BASE_1AND0` registers
+  - `def update()`: update result (automatically called internally)
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 Software Emulation Library for the RP2040 Interpolator peripheral.
 
-Note! The RP2350's Interpolator is almost perfectly compatible with the RP2040, but its behaviour is not identical. The main difference is a right rotate instead of a right shift, as well as broken behaviour of the OVERF flags. See the RP2350 datasheet's Interpolator section and the RP2350-E1 Erratum. This library will be updated to support the RP2350 Interpolator and explain the differences in detail in the future.
+Note! The RP2350's Interpolator is almost perfectly compatible with the RP2040,
+but its behaviour is not identical. The main difference is a right rotate
+instead of a right shift, as well as broken behaviour of the OVERF flags. See
+the RP2350 datasheet's Interpolator section and the RP2350-E1 Erratum. This
+library has untested support for the RP2350 Interpolator, verification of the
+implementation will be done soon.
 
 ## The Interpolator
 
@@ -45,7 +50,7 @@ INTERP_BASE:
              | \|                  _ |    /-------------------------------------------------------->|1 \     v    | | |           |  |--> OR --->|0 \        +---------+  
   RESULT0 -->|0 \   +--------+    | \|    |                                                 _ |     |  |--> ADD ----------------->|0 /           |  |------->| RESULT0 |  
              |  |-->| ACCUM0 |--->|0 \    |  +-------------+   +------+     +----------+   | \|  /->|0 /          | | |           |_/    /------>|1 /        +---------+  
-  RESULT1 -->|1 /   +--------+    |  |----+->| Right Shift |-->| Mask |--+--| Sign Ext |-->|1 \  |  |_/           | | |                  |       |_/                      
+  RESULT1 -->|1 /   +--------+    |  |----+->| Right Shift*|-->| Mask |--+--| Sign Ext |-->|1 \  |  |_/           | | |                  |       |_/                      
              |_/      ACCUM1 ---->|1 /       +-------------+   +------+  |  +----------+   |  |--+       +------+ | | |  /---------------/                                
                                   |_/                                    \---------------->|0 /  \------>| RAW0 |-----+--------------------------------\                  
                     +--------+                                                             |_/           +------+ | |    |                             v     +---------+  
@@ -53,7 +58,7 @@ INTERP_BASE:
                     +--------+     _                                                       | \           +------+ | |    |                       | \   ^     +---------+  
               _                   | \                                    /---------------->|0 \  /------>| RAW1 |-----+------------------------->|0 \  |                  
              | \      ACCUM0 ---->|1 \       +-------------+   +------+  |  +----------+   |  |--+   _   +------+ | | |  |                       |  |--/                  
-  RESULT1 -->|0 \   +--------+    |  |----+->| Right Shift |-->| Mask |--+--| Sign Ext |-->|1 /  |  | \           | | |  |         _        0 -->|1 /                     
+  RESULT1 -->|0 \   +--------+    |  |----+->| Right Shift*|-->| Mask |--+--| Sign Ext |-->|1 /  |  | \           | | |  |         _        0 -->|1 /                     
              |  |-->| ACCUM1 |--->|0 /    |  +-------------+   +------+     +----------+   |_/|  \->|0 \          | | |  |        | \            |_/|                     
   RESULT0 -->|1 /   +--------+    |_/|    |                                                   |     |  |--> ADD ----------------->|0 \              |        +---------+  
              |_/|                    |    \-------------------------------------------------------->|1 /     ^    | | |  |        |  |--> OR --------------->| RESULT1 |  
@@ -67,6 +72,10 @@ INTERP_BASE:
 
 Note: each Interpolator only has either a CLAMP or a BLEND unit. This diagram
 shows both to avoid needing to draw 2 diagrams.
+
+Note \*: The RP2350 has a Right Rotate unit here instead of a right shift unit.
+This causes the OVERF flags to be of little use on the RP2350 if a nonzero
+shift amount is used.
 
 ## C++ Library
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,71 @@ shift amount is used.
 The `CMakeLists.txt` defines a header-only library `rp2040-interp` with main
 header `include/interp.h`.
 
-TODO: more documentation
+### `<interp.h>`
+
+- `enum InterpGeneration`: identifies the Interpolator variant
+  - `RP2040`
+  - `RP2350`
+  - `DEFAULT` (`RP2040`, or `RP2350` when `RP2040_INTERP_GENERATION_RP2350` is set`)
+
+- `struct InterpCtrl`: Interpolator lane settings bitfield
+  - `uint32_t shift : 5`
+  - `uint32_t mask_lsb : 5`
+  - `uint32_t mask_msb : 5`
+  - `bool is_signed : 1`
+  - `bool cross_input : 1`
+  - `bool cross_result : 1`
+  - `bool add_raw : 1`
+  - `uint32_t force_msb : 2`
+  - `bool blend : 1`
+  - `bool clamp : 1`
+  - `bool overf0 : 1`
+  - `bool overf1 : 1`
+  - `bool overf : 1`
+  - `static InterpCtrl from(uint32_t)`: convert from packed form
+  - `uint32_t to() const`: convert to packed form
+
+- `struct InterpState`: Snapshot of Interpolator state
+  - `uint32_t accum[2]`
+  - `uint32_t base[3]`
+  - `uint32_t ctrl[2]`
+  - `uint32_t peek[3]`
+  - `uint32_t peekraw[2]`
+  - `InterpState() = default`
+  - `InterpState(const InterpState&) = default`
+  - `InterpState(const InterpSW<N, G>&)`: save state from a simulated Interpolator instance
+  - `InterpState(const InterpHW<N>&)`: save state from a hardware Interpolator instance
+  - `InterpState& operator=(const InterpState&) = default`
+  - `InterpState& operator=(const InterpSW<N, G>&)`: save state from a simulated Interpolator instance
+  - `InterpState& operator=(const InterpHW<N>&)`: save state from a hardware Interpolator instance
+  - `void save(const InterpSW<N, G>&)`:  save state from a simulated Interpolator instance
+  - `void save(const InterpHW<N>&)`:  save state from a hardware Interpolator instance
+  - `void restore(const InterpSW<N, G>&) const`:  restore state to a simulated Interpolator instance
+  - `void restore(const InterpHW<N>&) const`:  restore state to a hardware Interpolator instance
+
+- `struct InterpSW<size_t N, InterpGeneration G = InterpGeneration::DEFAULT>`: Software Simulation of an Interpolator
+  - N must be 0 or 1 and describes which interpolator instance is used
+  - G must be a variant of InterpGeneration and describes which generation of Interpolator is simulated
+  - `uint32_t accum[2]`
+  - `uint32_t base[3]`
+  - `uint32_t ctrl[2]`
+  - `uint32_t pop(size_t i)`: simulate read from `POP_LANE0` (i=0), `POP_LANE1` (i=1), or `POP_FULL` (i=2) registers
+  - `uint32_t peek(size_t i)`: simulate read from `PEEK_LANE0` (i=0), `PEEK_LANE1` (i=1), or `PEEK_FULL` (i=2) registers
+  - `uint32_t peekraw(size_t i)`: simulate read from `ACCUM0_ADD` (i=0) or `ACCUM1_ADD` (i=1) registers
+  - `void add(size_t i, uint32_t v)`: simulate write to `ACCUM0_ADD` (i=0) or `ACCUM1_ADD` (i=1) registers
+  - `void base01(uint32_t v)`: simulate write to `BASE_1AND0` registers
+  - `void update()`: update result (automatically called internally)
+
+- `struct InterpHW<size_t N>`: Hardware Wrapper with same API as `InterpSW<N>`
+  - only available when `RP2040_INTERP_WITH_HARDWARE` is set
+
+- `InterpSW0`: alias for `InterpSW<0>`
+- `InterpSW1`: alias for `InterpSW<1>`
+- `InterpHW0`: alias for `InterpHW<0>`
+- `InterpHW1`: alias for `InterpHW<1>`
+- `Interp<N>`: alias for `InterpSW<N>`, or `InterpHW<N>` when `RP2040_INTERP_WITH_HARDWARE` is set
+- `Interp0`: alias for `Interp<0>`
+- `Interp1`: alias for `Interp<1>`
 
 ## Python Library
 

--- a/include/interp-state.hpp
+++ b/include/interp-state.hpp
@@ -5,8 +5,8 @@
 #include "interp.h"
 #endif
 
-template <size_t M>
-void InterpState::save(const InterpSW<M>& sw) {
+template <size_t N, InterpGeneration G>
+void InterpState::save(const InterpSW<N, G>& sw) {
     ctrl[0] = sw.ctrl[0];
     ctrl[1] = sw.ctrl[1];
     accum[0] = sw.accum[0];
@@ -21,8 +21,8 @@ void InterpState::save(const InterpSW<M>& sw) {
     peekraw[1] = sw.smresult[1];
 }
 
-template <size_t M>
-void InterpState::restore(InterpSW<M>& sw) const {
+template <size_t N, InterpGeneration G>
+void InterpState::restore(InterpSW<N, G>& sw) const {
     sw.ctrl[0] = ctrl[0];
     sw.ctrl[1] = ctrl[1];
     sw.accum[0] = accum[0];
@@ -38,8 +38,8 @@ void InterpState::restore(InterpSW<M>& sw) const {
 }
 
 #if RP2040_INTERP_WITH_HARDWARE
-template <size_t M>
-void InterpState::save(InterpHW<M>& hw) {
+template <size_t N>
+void InterpState::save(InterpHW<N>& hw) {
     ctrl[0] = hw.ctrl[0];
     ctrl[1] = hw.ctrl[1];
     accum[0] = hw.accum[0];
@@ -54,8 +54,8 @@ void InterpState::save(InterpHW<M>& hw) {
     peekraw[1] = hw.peekraw(1);
 }
 
-template <size_t M>
-void InterpState::restore(InterpHW<M>& hw) const {
+template <size_t N>
+void InterpState::restore(InterpHW<N>& hw) const {
     hw.ctrl[0] = ctrl[0];
     hw.ctrl[1] = ctrl[1];
     hw.accum[0] = accum[0];

--- a/python/rp2040_interp/__init__.py
+++ b/python/rp2040_interp/__init__.py
@@ -1,1 +1,1 @@
-from .interp import InterpCtrl, Interp
+from .interp import InterpGeneration, InterpCtrl, Interp


### PR DESCRIPTION
This PR implements support for the RP2350's Interpolator peripheral.

The main difference is a right rotate instead of a right shift, which changes the calculations needed for the result and and overflow flags.

These changes are based solely on the RP2350 datasheet for now, since I don't have an RP2350 on hand at the moment. Next week I'll be back home where I have both an RP2040 and an RP2350 to test this.